### PR TITLE
add pixelated image rendering for the results page

### DIFF
--- a/src/pages/results.astro
+++ b/src/pages/results.astro
@@ -69,7 +69,13 @@ Astro.response.headers.set(
             <div class="relative flex border-b p-2 items-center justify-between">
               <div class="flex items-center">
                 <div class="flex items-center pl-4">
-                  <img src={getImageForMon(row.id)} width={64} height={64} />
+                  <img
+                    src={getImageForMon(row.id)}
+                    width={64}
+                    height={64}
+                    alt={`Sprite for ${ALL_MONS[row.id - 1]}`}
+                    style="image-rendering: pixelated;"
+                  />
                   <div class="pl-2 capitalize">{ALL_MONS[row.id - 1]}</div>
                 </div>
               </div>


### PR DESCRIPTION
Add the same style that was added to the index page to the results page as well.

Also add alt attribute for the images for 100% accessibility lighthouse.