### PR TITLE
FIx styling of footer

### DIFF
--- a/src/components/votes.tsx
+++ b/src/components/votes.tsx
@@ -1,6 +1,6 @@
-import { h, Fragment, FunctionComponent } from "preact";
+import { FunctionComponent } from "preact";
 import { useEffect, useState } from "preact/hooks";
-import { getOptionsForVote, getRandomPokemon } from "../data/getRandom";
+import { getOptionsForVote } from "../data/getRandom";
 import { ALL_MONS } from "../data/mons";
 
 const btn =

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,10 @@
 ---
 export interface Props {
   title: string;
+  headerTitle: string;
 }
 
-const { title } = Astro.props;
+const { title, headerTitle } = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -27,21 +28,32 @@ const { title } = Astro.props;
       content="Remake of roundest.t3.gg to see how fast it can be"
     />
   </head>
-  <body>
+  <body class="h-full flex flex-col justify-between items-center">
+    <header>
+      <div class="text-2xl text-center pt-8">{headerTitle}</div>
+    </header>
     <slot />
-    <style>
-      body {
-        @apply bg-gray-800 text-gray-100;
-      }
-    </style>
-    <div class="w-full text-xl text-center pb-2 fixed left-0 bottom-0">
+    <footer class="w-full text-xl text-center footer p-10">
       <a href="https://twitter.com/t3dotgg">Twitter</a>
-      <span class="p-4">{"-"}</span>
       <a href="/results"> Results</a>
-      <span class="p-4">{"-"}</span>
       <a href="/about"> About</a>
-      <span class="p-4">{"-"}</span>
       <a href="/"> Home</a>
-    </div>
+    </footer>
   </body>
 </html>
+<style>
+  html {
+    @apply h-full;
+  }
+  body {
+    @apply bg-gray-800 text-gray-100 mx-2;
+  }
+
+  .footer {
+    @apply gap-y-10 gap-x-4;
+  }
+  .footer *:not(:last-child) {
+    @apply after:content-['-'] after:mx-2;
+  }
+
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,17 +1,12 @@
 ---
 import Layout from "../layouts/Layout.astro";
 
-import Counter from "../components/votes";
-import { getOptionsForVote } from "../data/getRandom";
-
-const options = getOptionsForVote();
 ---
 
-<Layout title="Round But Faster - About">
+<Layout title="Round But Faster - About" headerTitle="About">
   <div class="h-screen flex flex-col justify-center items-center relative">
     <div class="flex flex-col items-center text-xl max-w-md md:max-w-lg">
       <div class="contents text-center">
-        <h2 class="text-2xl p-4">About</h2>
         <p>
           I made <a
             href="https://roundest.t3.gg"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,12 +7,6 @@ import { getOptionsForVote } from "../data/getRandom";
 const options = getOptionsForVote();
 ---
 
-<Layout title="Round But Faster">
-  <div class="h-screen flex flex-col justify-between items-center relative">
-    <div class="text-2xl text-center pt-8">Which Pokémon is Rounder?</div>
-
-    <Counter client:visible a={options[0]} b={options[1]} />
-
-    <div></div>
-  </div>
+<Layout title="Round But Faster" headerTitle="Which Pokémon is Rounder?">
+  <Counter client:visible a={options[0]} b={options[1]} />
 </Layout>

--- a/src/pages/results.astro
+++ b/src/pages/results.astro
@@ -56,11 +56,10 @@ Astro.response.headers.set(
 );
 ---
 
-<Layout title="Round But Faster">
+<Layout title="Round But Faster" headerTitle="Results">
   <div
     class="h-screen w-screen flex flex-col justify-between items-center relative"
   >
-    <h2 class="text-2xl p-4">Results</h2>
     <h3>As Of {createdAt.toLocaleString()}</h3>
     <div class="flex flex-col w-full max-w-2xl border">
       {


### PR DESCRIPTION
Footer is set to have absolute position at ``bottom-0`` and when you're browsing on a phone or a smaller screen the footer would cover parts of the main content.

---
This is how it used to look:
<div>
<img src="https://user-images.githubusercontent.com/22824333/190912819-98614a3a-20ca-45b7-a06a-235713f0a88b.jpg" width=200 alt="before"/>
<img src="https://user-images.githubusercontent.com/22824333/190912822-86a9759f-9806-48b1-8dd8-d6876239007c.jpg" width=200  alt="before"/>
</div>
__
This is how it looks now
<img src="https://user-images.githubusercontent.com/22824333/190913082-7caae47f-f707-46e2-85a0-9c65acb8114d.jpg" width=300 alt="final look" />